### PR TITLE
Upgrade `macos-12` job to `macos-13`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,13 +17,13 @@ jobs:
   build-wheel:
     strategy:
       matrix:
-        os: ['ubuntu-24.04', 'macos-12', 'macos-14', 'windows-2022']
+        os: ['ubuntu-24.04', 'macos-13', 'macos-14', 'windows-2022']
         arch: ['x86_64', 'aarch64']
         python: ['3.10']
         exclude:
           - os: 'ubuntu-24.04'  # TODO: needs qemu setup
             arch: 'aarch64'
-          - os: 'macos-12'
+          - os: 'macos-13'
             arch: 'aarch64'
           - os: 'macos-14'
             arch: 'x86_64'


### PR DESCRIPTION
As [macos-12 image is no longer supported](https://github.com/actions/runner-images/issues/10721) this PR updates macos-12 job to macos-13.